### PR TITLE
Correct Paul Sitoh in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @scealiontach @paulvizwiz @dajmaki @mziolekda @dasormeter
+* @scealiontach @paulwizviz @dajmaki @mziolekda @dasormeter


### PR DESCRIPTION
Correcting a typo in codeowners

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>