### PR TITLE
Update sdk to use 13.18

### DIFF
--- a/docker/daml-test.yaml
+++ b/docker/daml-test.yaml
@@ -133,12 +133,12 @@ services:
     entrypoint: "bash -c \"\
       sleep 30 && \
       java -jar ledger-api-test-tool_2.12.jar -v --host daml-rpc --target-port 9000 \
-        --timeout-scale-factor 5 \
-        --command-submission-ttl-scale-factor 5 \
+        --timeout-scale-factor 1.5 \
+        --command-submission-ttl-scale-factor 1 \
         || \
       java -jar ledger-api-test-tool_2.12.jar -v --host daml-rpc --target-port 9000 \
-        --timeout-scale-factor 5 \
-        --command-submission-ttl-scale-factor 5 \
+        --timeout-scale-factor 1 \
+        --command-submission-ttl-scale-factor 1 \
         \""
     depends_on:
       - daml-rpc

--- a/docker/ledger-api-testtool.docker
+++ b/docker/ledger-api-testtool.docker
@@ -13,8 +13,8 @@
 # limitations under the License.
 FROM ubuntu:bionic
 
-ARG DAML_SDK_VERSION=0.13.16
-ARG DAML_REPO_VERSION=100.13.16
+ARG DAML_SDK_VERSION=0.13.18
+ARG DAML_REPO_VERSION=100.13.18
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \

--- a/docker/ledger-api-testtool.docker
+++ b/docker/ledger-api-testtool.docker
@@ -13,8 +13,8 @@
 # limitations under the License.
 FROM ubuntu:bionic
 
-ARG DAML_SDK_VERSION=0.13.18
-ARG DAML_REPO_VERSION=100.13.18
+ARG DAML_SDK_VERSION=0.13.21
+ARG DAML_REPO_VERSION=100.13.21
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
  * Copyright 2019 Blockchain Technology Partners
  *
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
- <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>daml-on-sawtooth</groupId>
   <artifactId>daml-on-sawtooth</artifactId>
@@ -92,7 +90,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <protobuf.version>3.8.0</protobuf.version>
     <sawtooth.sdk.version>v0.1.3</sawtooth.sdk.version>
-    <daml.sdk.version>100.13.16</daml.sdk.version>
+    <daml.sdk.version>100.13.18</daml.sdk.version>
     <daml.bindings.version>2.3.3</daml.bindings.version>
     <scala.lang.version>2.12</scala.lang.version>
   </properties>
@@ -267,7 +265,7 @@
           <version>3.12.0</version>
           <configuration>
             <rulesets>
-<!--               <ruleset>/rulesets/java/maven-pmd-plugin-default.xml</ruleset>
+              <!--               <ruleset>/rulesets/java/maven-pmd-plugin-default.xml</ruleset>
               <ruleset>/category/java/bestpractices.xml</ruleset> -->
               <ruleset>/category/java/security.xml</ruleset>
             </rulesets>

--- a/sawtooth-daml-common/src/main/java/com/blockchaintp/sawtooth/daml/util/KeyValueUtils.java
+++ b/sawtooth-daml-common/src/main/java/com/blockchaintp/sawtooth/daml/util/KeyValueUtils.java
@@ -14,7 +14,6 @@ package com.blockchaintp.sawtooth.daml.util;
 import java.util.List;
 import java.util.Map;
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId;
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey;
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission;
 import com.google.common.collect.BiMap;
@@ -29,11 +28,13 @@ public final class KeyValueUtils {
   /**
    * Take a DamlSubmission and return the mapping of the DamlStateKeys to sawtooth
    * addresses which will be used as state input to this submission.
+   *
    * @param submission the DamlSubmission to be analyzed
    * @param keyCase    the particular type of input key we are interested in. If
    *                   null, all keys.
    * @return a mapping of DamlStateKey to address
    */
+  @Deprecated
   public static Map<DamlStateKey, String> submissionToDamlStateAddress(final DamlSubmission submission,
       final DamlStateKey.KeyCase keyCase) {
     List<DamlStateKey> inputDamlStateList = submission.getInputDamlStateList();
@@ -49,26 +50,12 @@ public final class KeyValueUtils {
   /**
    * Take a DamlSubmission and return the mapping of the DamlStateKeys to sawtooth
    * addresses which will be used as state input to this submission.
+   *
    * @param submission the DamlSubmission to be analyzed
    * @return a mapping of DamlStateKey to address
    */
   public static Map<DamlStateKey, String> submissionToDamlStateAddress(final DamlSubmission submission) {
     return submissionToDamlStateAddress(submission, null);
-  }
-
-  /**
-   * Take a DamlSubmission and return the mapping of the DamlLogEntryId to
-   * sawtooth addresses which will be used as input to this submission.
-   * @param submission the DamlSubmission to be analyzed
-   * @return a mapping of DamlLogEntryId to address
-   */
-  public static Map<DamlLogEntryId, String> submissionToLogAddressMap(final DamlSubmission submission) {
-    List<DamlLogEntryId> inputLogEntriesList = submission.getInputLogEntriesList();
-    BiMap<DamlLogEntryId, String> inputLogEntryKeys = HashBiMap.create();
-    for (DamlLogEntryId id : inputLogEntriesList) {
-      inputLogEntryKeys.put(id, Namespace.makeDamlLogEntryAddress(id));
-    }
-    return inputLogEntryKeys;
   }
 
   private KeyValueUtils() {

--- a/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothWriteService.java
+++ b/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothWriteService.java
@@ -228,7 +228,7 @@ public final class SawtoothWriteService implements WriteService {
     }
   }
 
-  private synchronized Future sendToValidator(final Batch batch) {
+  private Future sendToValidator(final Batch batch) {
     // Push to TraceTransaction class
 
     try {

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/DamlCommitter.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/DamlCommitter.java
@@ -28,6 +28,7 @@ import scala.Tuple2;
  * An interface providing indirection to the KeyValueCommitting class from
  * participant-state-kvutils. This is valuable for unit testing and potential
  * dependency injection.
+ *
  * @author scealiontach
  */
 public interface DamlCommitter {
@@ -35,20 +36,19 @@ public interface DamlCommitter {
   /**
    * Delegate method to the KeyValueCommitting class, but also providing some
    * useful java to scala and vice versa type tidying.
-   * @param config          the current configuration of the Daml ledger
-   * @param entryId         the proposed entry id for the log entry resulting from
-   *                        this call
-   * @param recordTime      the current maximum record time
-   * @param submission      the DamlSubmission to be processed
-   * @param inputLogEntries the log entries which will be required as input to
-   *                        process this submission
-   * @param stateMap        the key/value pairs that will be required to
-   *                        successfully process this submission
+   *
+   * @param config     the current configuration of the Daml ledger
+   * @param entryId    the proposed entry id for the log entry resulting from this
+   *                   call
+   * @param recordTime the current maximum record time
+   * @param submission the DamlSubmission to be processed
+   * @param stateMap   the key/value pairs that will be required to successfully
+   *                   process this submission
    * @return A scala tuple of DamlLogEntry which should be created, and a map of
    *         the key/value pairs that should be written to the ledger
    */
   Tuple2<DamlLogEntry, java.util.Map<DamlStateKey, DamlStateValue>> processSubmission(Configuration config,
       DamlLogEntryId entryId, Timestamp recordTime, DamlSubmission submission,
-      java.util.Map<DamlLogEntryId, DamlLogEntry> inputLogEntries, Map<DamlStateKey, Option<DamlStateValue>> stateMap);
+      Map<DamlStateKey, Option<DamlStateValue>> stateMap);
 
 }

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlCommitterImpl.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlCommitterImpl.java
@@ -30,6 +30,7 @@ import scala.collection.immutable.Map;
 
 /**
  * The concrete implementation of DamlCommitter.
+ *
  * @author scealiontach
  */
 public class DamlCommitterImpl implements DamlCommitter {
@@ -38,6 +39,7 @@ public class DamlCommitterImpl implements DamlCommitter {
   /**
    * Build a DamlCommitterImpl. The Engine to be used is passed in to allow reuse
    * since Engine initialization can be costly.
+   *
    * @param damlEngine the Engine to be used for this committer
    */
   public DamlCommitterImpl(final Engine damlEngine) {
@@ -47,12 +49,10 @@ public class DamlCommitterImpl implements DamlCommitter {
   @Override
   public final Tuple2<DamlLogEntry, java.util.Map<DamlStateKey, DamlStateValue>> processSubmission(
       final Configuration config, final DamlLogEntryId entryId, final Timestamp recordTime,
-      final DamlSubmission submission, final java.util.Map<DamlLogEntryId, DamlLogEntry> inputLogEntries,
-      final java.util.Map<DamlStateKey, Option<DamlStateValue>> stateMap) {
+      final DamlSubmission submission, final java.util.Map<DamlStateKey, Option<DamlStateValue>> stateMap) {
 
-    Tuple2<DamlLogEntry, Map<DamlStateKey, DamlStateValue>> processedSubmission = KeyValueCommitting.processSubmission(
-        this.engine, config, entryId, recordTime, submission, mapToScalaImmutableMap(inputLogEntries),
-        mapToScalaImmutableMap(stateMap));
+    Tuple2<DamlLogEntry, Map<DamlStateKey, DamlStateValue>> processedSubmission = KeyValueCommitting
+        .processSubmission(this.engine, config, entryId, recordTime, submission, mapToScalaImmutableMap(stateMap));
     DamlLogEntry logEntry = processedSubmission._1;
     java.util.Map<DamlStateKey, DamlStateValue> stateUpdateMap = scalaMapToMap(processedSubmission._2);
     return Tuple2.apply(logEntry, stateUpdateMap);

--- a/sawtooth-daml-tp/src/test/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandlerTest.java
+++ b/sawtooth-daml-tp/src/test/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandlerTest.java
@@ -192,7 +192,7 @@ public class DamlTransactionHandlerTest {
     Map<DamlStateKey, DamlStateValue> stateMap = new HashMap<>();
     DamlStateValue archiveValue = DamlStateValue.newBuilder().setArchive(archive).build();
     stateMap.put(archiveKey, archiveValue);
-    when(committer.processSubmission(any(), any(), any(), any(), any(), any()))
+    when(committer.processSubmission(any(), any(), any(), any(), any()))
         .thenReturn(Tuple2.apply(DamlLogEntry.getDefaultInstance(), stateMap));
     try {
       handler.apply(transactionRequest, state);


### PR DESCRIPTION
Updates to SDK 13.18
Simplifies some overall code, and demanded updating the test tool to SDK 13.21, as well as some adjustments to default TimeModel code and the daml-test.yaml