### PR TITLE
Hotfix correct readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Contribution guildines in [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Running daml-on-sawtooth locally
 
-See [BUILD.md](build.md) for instruction to build and run `daml-on-sawtooth`.
+See [BUILD.md](BUILD.md) for instruction to build and run `daml-on-sawtooth`.
 
 #### Inspecting daml-on-sawtooth
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Contribution guildines in [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Running daml-on-sawtooth locally
 
-See [BUILD.md](Build.md) for instruction to build and run `daml-on-sawtooth`.
+See [BUILD.md](build.md) for instruction to build and run `daml-on-sawtooth`.
 
 #### Inspecting daml-on-sawtooth
 


### PR DESCRIPTION
Correct link to BUILD.md from README due to case sensitivity issue