### PR TITLE
Multithreaded tp

### DIFF
--- a/docker/daml-test.yaml
+++ b/docker/daml-test.yaml
@@ -44,6 +44,7 @@ services:
         sawset genesis && \
         sawadm genesis config-genesis.batch && \
         sawtooth-validator -v \
+          --scheduler parallel \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \
           --bind consensus:tcp://eth0:5050 \
@@ -132,13 +133,24 @@ services:
     container_name: ledger-api-testtool
     entrypoint: "bash -c \"\
       sleep 30 && \
-      java -jar ledger-api-test-tool_2.12.jar -v --host daml-rpc --target-port 9000 \
+      java -jar ledger-api-test-tool_2.12.jar --host daml-rpc --target-port 9000 \
+        --timeout-scale-factor 1.5 \
+         \
+        --command-submission-ttl-scale-factor 1 \
+        || \
+      java -jar ledger-api-test-tool_2.12.jar --host daml-rpc --target-port 9000 \
+        --timeout-scale-factor 1.5 \
+         \
+        --command-submission-ttl-scale-factor 1 \
+        && \
+      java -jar ledger-api-test-tool_2.12.jar --host daml-rpc --target-port 9000 \
         --timeout-scale-factor 1.5 \
         --command-submission-ttl-scale-factor 1 \
         || \
-      java -jar ledger-api-test-tool_2.12.jar -v --host daml-rpc --target-port 9000 \
-        --timeout-scale-factor 1 \
+      java -jar ledger-api-test-tool_2.12.jar --host daml-rpc --target-port 9000 \
+        --timeout-scale-factor 1.5 \
         --command-submission-ttl-scale-factor 1 \
+
         \""
     depends_on:
       - daml-rpc

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/BlockingStreamContext.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/BlockingStreamContext.java
@@ -1,0 +1,268 @@
+/* Copyright 2016, 2017 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+
+package com.blockchaintp.sawtooth.daml.processor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import sawtooth.sdk.messaging.Future;
+import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.processor.Context;
+import sawtooth.sdk.processor.exceptions.InternalError;
+import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
+import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
+import sawtooth.sdk.protobuf.Event;
+import sawtooth.sdk.protobuf.Event.Attribute;
+import sawtooth.sdk.protobuf.Event.Builder;
+import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.TpEventAddRequest;
+import sawtooth.sdk.protobuf.TpEventAddResponse;
+import sawtooth.sdk.protobuf.TpReceiptAddDataRequest;
+import sawtooth.sdk.protobuf.TpReceiptAddDataResponse;
+import sawtooth.sdk.protobuf.TpStateDeleteRequest;
+import sawtooth.sdk.protobuf.TpStateDeleteResponse;
+import sawtooth.sdk.protobuf.TpStateEntry;
+import sawtooth.sdk.protobuf.TpStateGetRequest;
+import sawtooth.sdk.protobuf.TpStateGetResponse;
+import sawtooth.sdk.protobuf.TpStateSetRequest;
+import sawtooth.sdk.protobuf.TpStateSetResponse;
+
+/**
+ * Client state that interacts with the context manager through Stream
+ * networking.
+ */
+public class BlockingStreamContext implements Context {
+
+  /**
+   * The stream networking for this class.
+   */
+  private Stream stream;
+
+  /**
+   * The id for a specific context.
+   */
+  private String contextId;
+
+  /**
+   * How long to wait for a networking response.
+   */
+  private static final int TIME_OUT = 20;
+
+  /**
+   * The constructor for this class.
+   * @param myStream    a networking stream
+   * @param myContextId a context id
+   */
+  public BlockingStreamContext(final Stream myStream, final String myContextId) {
+    this.stream = myStream;
+    this.contextId = myContextId;
+  }
+
+  /**
+   * Make a Get request on a specific context specified by contextId.
+   * @param addresses a collection of address Strings
+   * @return Map where the keys are addresses, values Bytestring
+   * @throws InternalError               something went wrong processing
+   *                                     transaction
+   * @throws InvalidTransactionException an invalid transaction was encountered
+   */
+  @Override
+  public final Map<String, ByteString> getState(final Collection<String> addresses)
+      throws InternalError, InvalidTransactionException {
+    TpStateGetRequest getRequest = TpStateGetRequest.newBuilder().addAllAddresses(addresses)
+        .setContextId(this.contextId).build();
+    TpStateGetResponse getResponse = null;
+    synchronized (stream) {
+      Future future = stream.send(Message.MessageType.TP_STATE_GET_REQUEST, getRequest.toByteString());
+      try {
+        getResponse = TpStateGetResponse.parseFrom(future.getResult(TIME_OUT));
+      } catch (InterruptedException iee) {
+        throw new InternalError(iee.toString());
+      } catch (InvalidProtocolBufferException ipbe) {
+        // server didn't respond with a GetResponse
+        throw new InternalError(ipbe.toString());
+      } catch (ValidatorConnectionError vce) {
+        throw new InternalError(vce.toString());
+      } catch (Exception e) {
+        throw new InternalError(e.toString());
+      }
+    }
+    Map<String, ByteString> results = new HashMap<String, ByteString>();
+    if (getResponse != null) {
+      if (getResponse.getStatus() == TpStateGetResponse.Status.AUTHORIZATION_ERROR) {
+        throw new InvalidTransactionException("Tried to get unauthorized address " + addresses.toString());
+      }
+      for (TpStateEntry entry : getResponse.getEntriesList()) {
+        results.put(entry.getAddress(), entry.getData());
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Make a Set request on a specific context specified by contextId.
+   * @param addressValuePairs A collection of Map.Entry's
+   * @return addressesThatWereSet, A collection of address Strings that were set
+   * @throws InternalError               something went wrong processing
+   *                                     transaction
+   * @throws InvalidTransactionException an invalid transaction was encountered
+   */
+  @Override
+  public final Collection<String> setState(final Collection<java.util.Map.Entry<String, ByteString>> addressValuePairs)
+      throws InternalError, InvalidTransactionException {
+    ArrayList<TpStateEntry> entryArrayList = new ArrayList<TpStateEntry>();
+    for (Map.Entry<String, ByteString> entry : addressValuePairs) {
+      TpStateEntry ourTpStateEntry = TpStateEntry.newBuilder().setAddress(entry.getKey()).setData(entry.getValue())
+          .build();
+      entryArrayList.add(ourTpStateEntry);
+    }
+    TpStateSetRequest setRequest = TpStateSetRequest.newBuilder().addAllEntries(entryArrayList)
+        .setContextId(this.contextId).build();
+    TpStateSetResponse setResponse = null;
+    synchronized (stream) {
+      Future future = stream.send(Message.MessageType.TP_STATE_SET_REQUEST, setRequest.toByteString());
+      try {
+        setResponse = TpStateSetResponse.parseFrom(future.getResult(TIME_OUT));
+      } catch (InterruptedException iee) {
+        throw new InternalError(iee.toString());
+      } catch (InvalidProtocolBufferException ipbe) {
+        // server didn't respond with a SetResponse
+        throw new InternalError(ipbe.toString());
+      } catch (ValidatorConnectionError vce) {
+        throw new InternalError(vce.toString());
+      } catch (Exception e) {
+        throw new InternalError(e.toString());
+      }
+    }
+    ArrayList<String> addressesThatWereSet = new ArrayList<String>();
+    if (setResponse != null) {
+      if (setResponse.getStatus() == TpStateSetResponse.Status.AUTHORIZATION_ERROR) {
+        throw new InvalidTransactionException("Tried to set unauthorized address " + addressValuePairs.toString());
+      }
+      for (String address : setResponse.getAddressesList()) {
+        addressesThatWereSet.add(address);
+      }
+    }
+
+    return addressesThatWereSet;
+  }
+
+  @Override
+  public final Collection<String> deleteState(final Collection<String> addresses)
+      throws InternalError, InvalidTransactionException {
+    TpStateDeleteRequest delRequest = TpStateDeleteRequest.newBuilder().addAllAddresses(addresses)
+        .setContextId(this.contextId).build();
+    TpStateDeleteResponse delResponse = null;
+    synchronized (stream) {
+      Future future = stream.send(Message.MessageType.TP_STATE_DELETE_REQUEST, delRequest.toByteString());
+      try {
+        delResponse = TpStateDeleteResponse.parseFrom(future.getResult(TIME_OUT));
+      } catch (InterruptedException iee) {
+        throw new InternalError(iee.toString());
+      } catch (InvalidProtocolBufferException ipbe) {
+        // server didn't respond with a DeleteResponse
+        throw new InternalError(ipbe.toString());
+      } catch (ValidatorConnectionError vce) {
+        throw new InternalError(vce.toString());
+      } catch (Exception e) {
+        throw new InternalError(e.toString());
+      }
+    }
+    List<String> results = new ArrayList<>();
+    if (delResponse != null) {
+      if (delResponse.getStatus() == TpStateDeleteResponse.Status.AUTHORIZATION_ERROR) {
+        throw new InvalidTransactionException("Tried to delete unauthorized address " + addresses.toString());
+      }
+      for (String entry : delResponse.getAddressesList()) {
+        results.add(entry);
+      }
+    }
+
+    return results;
+  }
+
+  @Override
+  public final void addReceiptData(final ByteString data) throws InternalError {
+    TpReceiptAddDataRequest addDataRequest = TpReceiptAddDataRequest.newBuilder().setContextId(contextId).setData(data)
+        .build();
+    TpReceiptAddDataResponse addDataResponse = null;
+    synchronized (stream) {
+      Future future = stream.send(Message.MessageType.TP_RECEIPT_ADD_DATA_REQUEST, addDataRequest.toByteString());
+      try {
+        addDataResponse = TpReceiptAddDataResponse.parseFrom(future.getResult(TIME_OUT));
+      } catch (InterruptedException iee) {
+        throw new InternalError(iee.toString());
+      } catch (InvalidProtocolBufferException ipbe) {
+        // server didn't respond with a ReceiptAddResponse
+        throw new InternalError(ipbe.toString());
+      } catch (ValidatorConnectionError vce) {
+        throw new InternalError(vce.toString());
+      } catch (Exception e) {
+        throw new InternalError(e.toString());
+      }
+    }
+    if (addDataResponse != null) {
+      if (addDataResponse.getStatus() == TpReceiptAddDataResponse.Status.ERROR) {
+        throw new InternalError(String.format("Failed to add receipt data %s", data));
+      }
+    }
+  }
+
+  @Override
+  public final void addEvent(final String eventType, final Collection<Entry<String, String>> attributes,
+      final ByteString data) throws InternalError {
+    List<Attribute> attList = new ArrayList<>();
+    for (Map.Entry<String, String> entry : attributes) {
+      Attribute att = Attribute.newBuilder().setKey(entry.getKey()).setValue(entry.getValue()).build();
+      attList.add(att);
+    }
+    Builder evtBuilder = Event.newBuilder().addAllAttributes(attList).setEventType(eventType);
+    if (data != null) {
+      evtBuilder.setData(data);
+    }
+    Event evt = evtBuilder.build();
+    TpEventAddRequest evtAddRequest = TpEventAddRequest.newBuilder().setContextId(contextId).setEvent(evt).build();
+    TpEventAddResponse evtAddResponse = null;
+    synchronized (stream) {
+      Future future = stream.send(Message.MessageType.TP_EVENT_ADD_REQUEST, evtAddRequest.toByteString());
+      try {
+        evtAddResponse = TpEventAddResponse.parseFrom(future.getResult(TIME_OUT));
+      } catch (InterruptedException iee) {
+        throw new InternalError(iee.toString());
+      } catch (InvalidProtocolBufferException ipbe) {
+        // server didn't respond with a EventAddResponse
+        throw new InternalError(ipbe.toString());
+      } catch (ValidatorConnectionError vce) {
+        throw new InternalError(vce.toString());
+      } catch (Exception e) {
+        throw new InternalError(e.toString());
+      }
+    }
+    if (evtAddResponse != null) {
+      if (evtAddResponse.getStatus() == TpEventAddResponse.Status.ERROR) {
+        throw new InternalError(String.format("Failed to add event %s, %s, %s", eventType, attributes, data));
+      }
+    }
+  }
+
+}

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/DamlTransactionProcessorMain.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/DamlTransactionProcessorMain.java
@@ -19,7 +19,6 @@ import com.blockchaintp.sawtooth.daml.processor.impl.DamlTransactionHandler;
 import com.digitalasset.daml.lf.engine.Engine;
 
 import sawtooth.sdk.processor.TransactionHandler;
-import sawtooth.sdk.processor.TransactionProcessor;
 
 /**
  * A basic Main class for DamlTransactionProcessor.
@@ -36,11 +35,10 @@ public final class DamlTransactionProcessorMain {
    */
   public static void main(final String[] args) {
     Logger.getGlobal().setLevel(Level.ALL);
-    TransactionProcessor transactionProcessor = new TransactionProcessor(args[0]);
     Engine engine = new Engine();
     DamlCommitter committer = new DamlCommitterImpl(engine);
     TransactionHandler handler = new DamlTransactionHandler(committer);
-    transactionProcessor.addHandler(handler);
+    MTTransactionProcessor transactionProcessor = new MTTransactionProcessor(handler, args[0]);
     LOGGER.info(String.format("Added handler %s", DamlTransactionHandler.class.getName()));
     Thread thread = new Thread(transactionProcessor);
     thread.start();

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/LedgerState.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/LedgerState.java
@@ -172,14 +172,13 @@ public interface LedgerState {
   /**
    * @param entryId          Id of this log entry
    * @param entry            the log entry to set
-   * @param currentEntryList the current log entry index list
    * @return the new entry list after the addition
    * @throws InvalidTransactionException when there is an error relating to the
    *                                     client input
    * @throws InternalError               when there is an unexpected back end
    *                                     error.
    */
-  List<String> addDamlLogEntry(DamlLogEntryId entryId, DamlLogEntry entry, List<String> currentEntryList)
+  List<String> addDamlLogEntry(DamlLogEntryId entryId, DamlLogEntry entry)
       throws InternalError, InvalidTransactionException;
 
   /**
@@ -187,12 +186,11 @@ public interface LedgerState {
    *
    * @param entryId the id of this log entry
    * @param entry   the entry itself
-   * @param offset  the offset of the entry itself
    * @throws InternalError               when there is an unexpected back end
    *                                     error
    * @throws InvalidTransactionException when the data itself is invalid
    */
-  void sendLogEvent(DamlLogEntryId entryId, DamlLogEntry entry, long offset)
+  void sendLogEvent(DamlLogEntryId entryId, DamlLogEntry entry)
       throws InternalError, InvalidTransactionException;
 
   /**

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/MTTransactionProcessor.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/MTTransactionProcessor.java
@@ -1,0 +1,186 @@
+/* Copyright 2019 Blockchain Technology Partners
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+package com.blockchaintp.sawtooth.daml.processor;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import sawtooth.sdk.messaging.Future;
+import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.messaging.ZmqStream;
+import sawtooth.sdk.processor.Context;
+import sawtooth.sdk.processor.StreamContext;
+import sawtooth.sdk.processor.TransactionHandler;
+import sawtooth.sdk.processor.exceptions.InternalError;
+import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
+import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
+import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.PingResponse;
+import sawtooth.sdk.protobuf.TpProcessRequest;
+import sawtooth.sdk.protobuf.TpProcessResponse;
+import sawtooth.sdk.protobuf.TpUnregisterRequest;
+
+/**
+ * A multithreaded Sawtooth transaction processor.
+ */
+public class MTTransactionProcessor implements Runnable {
+
+  private static final Logger LOGGER = Logger.getLogger(MTTransactionProcessor.class.getName());
+
+  private TransactionHandler handler;
+
+  private BlockingQueue<Map.Entry<String, TpProcessResponse>> outQueue;
+
+  private Stream stream;
+
+  private ExecutorService executor;
+
+  /**
+   * Constructs a MTTransactionProcessor utilizing the given transaction handler.
+   * NOTE: The TransactionHandler.apply() method must be thread-safe.
+   * @param txHandler The handler to apply to this processor
+   * @param address   the address of the ZMQ stream
+   */
+  public MTTransactionProcessor(final TransactionHandler txHandler, final String address) {
+    this.handler = txHandler;
+    this.outQueue = new LinkedBlockingQueue<>();
+    this.stream = new ZmqStream(address);
+    this.executor = Executors.newCachedThreadPool();
+  }
+
+  @Override
+  public final void run() {
+    boolean stopped = false;
+    try {
+      this.register();
+      int outStandingTx = 0;
+      while (!stopped) {
+        int enqueueCount = 0;
+        int dequeueCount = 0;
+        try {
+          Message inMessage = this.stream.receive(1);
+          while (inMessage != null) {
+            if (inMessage.getMessageType() == Message.MessageType.PING_REQUEST) {
+              LOGGER.info("Recieved Ping Message.");
+              PingResponse pingResponse = PingResponse.newBuilder().build();
+              this.stream.sendBack(Message.MessageType.PING_RESPONSE, inMessage.getCorrelationId(),
+                  pingResponse.toByteString());
+            } else {
+              Runnable processMessage = new ProcessRunnable(inMessage, this.handler, this.outQueue);
+              this.executor.submit(processMessage);
+              enqueueCount++;
+              inMessage = this.stream.receive(1);
+            }
+          }
+          if (inMessage == null) {
+            // Then the validator has disconnected and we need to reregister.
+            this.register();
+          }
+        } catch (TimeoutException e) {
+          LOGGER.log(Level.FINER, "Nothing to process on this iteration.");
+        }
+        Map.Entry<String, TpProcessResponse> outPair = outQueue.poll(1, TimeUnit.MILLISECONDS);
+        while (outPair != null) {
+          this.stream.sendBack(Message.MessageType.TP_PROCESS_REQUEST, outPair.getKey(),
+              outPair.getValue().toByteString());
+          dequeueCount++;
+          outPair = outQueue.poll(1, TimeUnit.MILLISECONDS);
+        }
+        outStandingTx += enqueueCount;
+        outStandingTx -= dequeueCount;
+        LOGGER.info(String.format("Enqueued %s transactions, Dequeued %s responses, outStanding tx=%s", enqueueCount,
+            dequeueCount, outStandingTx));
+      }
+    } catch (InterruptedException e) {
+      LOGGER.info("Processor interrupted, shutting down");
+    }
+
+  }
+
+  private void register() {
+    TpUnregisterRequest unregisterRequest = TpUnregisterRequest.newBuilder().build();
+    LOGGER.info("Registering TP");
+    boolean registered = false;
+    while (!registered) {
+      try {
+        Future fut = this.stream.send(Message.MessageType.TP_UNREGISTER_REQUEST, unregisterRequest.toByteString());
+        fut.getResult();
+        registered = true;
+      } catch (InterruptedException | ValidatorConnectionError e) {
+        LOGGER.log(Level.WARNING, "Failed to register with validator, retrying...", e);
+      }
+    }
+  }
+
+  /**
+   * A Runnable which processes a single Message.
+   */
+  private final class ProcessRunnable implements Runnable {
+
+    private Message message;
+    private BlockingQueue<Entry<String, TpProcessResponse>> responses;
+    private TransactionHandler handler;
+
+    ProcessRunnable(final Message m, final TransactionHandler txHandler,
+        final BlockingQueue<Map.Entry<String, TpProcessResponse>> responseQueue) {
+      this.message = m;
+      this.handler = txHandler;
+      this.responses = responseQueue;
+    }
+
+    @Override
+    public void run() {
+      try {
+        TpProcessRequest transactionRequest = TpProcessRequest.parseFrom(this.message.getContent());
+        Context state = new StreamContext(stream, transactionRequest.getContextId());
+
+        TpProcessResponse.Builder builder = TpProcessResponse.newBuilder();
+        try {
+          handler.apply(transactionRequest, state);
+          builder.setStatus(TpProcessResponse.Status.OK);
+        } catch (InvalidTransactionException ite) {
+          LOGGER.log(Level.WARNING, "Invalid Transaction: " + ite.toString(), ite);
+          builder.setStatus(TpProcessResponse.Status.INVALID_TRANSACTION);
+          builder.setMessage(ite.getMessage());
+          if (ite.getExtendedData() != null) {
+            builder.setExtendedData(ByteString.copyFrom(ite.getExtendedData()));
+          }
+        } catch (InternalError ie) {
+          LOGGER.log(Level.WARNING, "State Exception!: " + ie.toString(), ie);
+          builder.setStatus(TpProcessResponse.Status.INTERNAL_ERROR);
+          builder.setMessage(ie.getMessage());
+          if (ie.getExtendedData() != null) {
+            builder.setExtendedData(ByteString.copyFrom(ie.getExtendedData()));
+          }
+        }
+        responses.put(Map.entry(message.getCorrelationId(), builder.build()));
+      } catch (InvalidProtocolBufferException e) {
+        LOGGER.log(Level.WARNING, "InvalidProtocolBufferException!: " + e.toString(), e);
+      } catch (InterruptedException e) {
+        LOGGER.log(Level.WARNING, "Interrupted while queueing a response!: " + e.toString(), e);
+      }
+    }
+
+  }
+
+}

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlLedgerState.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlLedgerState.java
@@ -205,15 +205,13 @@ public final class DamlLedgerState implements LedgerState {
   }
 
   @Override
-  public List<String> addDamlLogEntry(final DamlLogEntryId entryId, final DamlLogEntry entry,
-      final List<String> currentEntryList) throws InternalError, InvalidTransactionException {
+  public List<String> addDamlLogEntry(final DamlLogEntryId entryId, final DamlLogEntry entry)
+      throws InternalError, InvalidTransactionException {
     Map<DamlLogEntryId, DamlLogEntry> setMap = new HashMap<>();
     setMap.put(entryId, entry);
-    String[] addresses = addDamlLogEntries(setMap.entrySet());
-    List<String> retList = new ArrayList<>(currentEntryList);
-    retList.addAll(Arrays.asList(addresses));
-    sendLogEvent(entryId, entry, retList.size());
-    return retList;
+    addDamlLogEntries(setMap.entrySet());
+    sendLogEvent(entryId, entry);
+    return new ArrayList<>();
   }
 
   @Override
@@ -248,11 +246,11 @@ public final class DamlLedgerState implements LedgerState {
   }
 
   @Override
-  public void sendLogEvent(final DamlLogEntryId entryId, final DamlLogEntry entry, final long offset)
+  public void sendLogEvent(final DamlLogEntryId entryId, final DamlLogEntry entry)
       throws InternalError, InvalidTransactionException {
     Map<String, String> attrMap = new HashMap<>();
     attrMap.put(EventConstants.DAML_LOG_ENTRY_ID_EVENT_ATTRIBUTE, entryId.getEntryId().toStringUtf8());
-    attrMap.put(EventConstants.DAML_OFFSET_EVENT_ATTRIBUTE, Long.toString(offset));
+    attrMap.put(EventConstants.DAML_OFFSET_EVENT_ATTRIBUTE, Long.toString(1));
     ByteString packedData = KeyValueCommitting.packDamlLogEntry(entry);
     ByteString compressedData = compressByteString(packedData);
     LOGGER.info(String.format("Sending event for %s, size=%s, compressed=%s", entryId.getEntryId().toStringUtf8(),

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
@@ -110,9 +110,8 @@ public final class DamlTransactionHandler implements TransactionHandler {
     long fetchStateStart = System.currentTimeMillis();
     Map<DamlStateKey, Option<DamlStateValue>> stateMap = buildStateMap(ledgerState, txHeader, submission);
 
-    List<String> currentLogEntryList = ledgerState.getLogEntryIndex();
     long recordStateStart = System.currentTimeMillis();
-    recordState(ledgerState, submission, stateMap, entryId, currentLogEntryList);
+    recordState(ledgerState, submission, stateMap, entryId);
 
     long processFinished = System.currentTimeMillis();
     long recordStateTime = processFinished - recordStateStart;
@@ -163,9 +162,6 @@ public final class DamlTransactionHandler implements TransactionHandler {
     }
     if (!inputList.contains(com.blockchaintp.sawtooth.timekeeper.util.Namespace.TIMEKEEPER_GLOBAL_RECORD)) {
       throw new InvalidTransactionException(String.format("TIMEKEEPER_GLOBAL_RECORD not declared as input"));
-    }
-    if (!inputList.contains(Namespace.DAML_LOG_ENTRY_LIST)) {
-      throw new InvalidTransactionException(String.format("DAML_LOG_ENTRY_LIST not declared as input"));
     }
     Map<DamlStateKey, DamlStateValue> inputStates = ledgerState.getDamlStates(inputDamlStateKeys.keySet());
 
@@ -225,8 +221,8 @@ public final class DamlTransactionHandler implements TransactionHandler {
   }
 
   private void recordState(final LedgerState ledgerState, final DamlSubmission submission,
-      final Map<DamlStateKey, Option<DamlStateValue>> stateMap, final DamlLogEntryId entryId,
-      final List<String> currentLogEntryList) throws InternalError, InvalidTransactionException {
+      final Map<DamlStateKey, Option<DamlStateValue>> stateMap, final DamlLogEntryId entryId)
+      throws InternalError, InvalidTransactionException {
 
     long processStart = System.currentTimeMillis();
     String ledgerEffectiveTime = null;
@@ -248,8 +244,7 @@ public final class DamlTransactionHandler implements TransactionHandler {
     DamlLogEntry newLogEntry = processSubmission._1;
     LOGGER.fine(String.format("Recording log at %s, address=%s", entryId, Namespace.makeAddressForType(entryId),
         newLogEntry.toByteString().size()));
-    List<String> newLogEntryList = ledgerState.addDamlLogEntry(entryId, newLogEntry, currentLogEntryList);
-    ledgerState.updateLogEntryIndex(newLogEntryList);
+    ledgerState.addDamlLogEntry(entryId, newLogEntry);
     long recordFinish = System.currentTimeMillis();
     long processTime = recordStart - processStart;
     long setStateTime = recordFinish - recordStart;

--- a/sawtooth-daml-tp/src/test/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlLedgerStateTest.java
+++ b/sawtooth-daml-tp/src/test/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlLedgerStateTest.java
@@ -153,7 +153,7 @@ public class DamlLedgerStateTest {
             .build())
         .build();
     try {
-      ledgerState.addDamlLogEntry(firstKey, firstVal, new ArrayList<String>());
+      ledgerState.addDamlLogEntry(firstKey, firstVal);
       DamlLogEntry testVal = ledgerState.getDamlLogEntry(firstKey);
       assertTrue(String.format("%s!=%s", firstVal, testVal), firstVal.equals(testVal));
       // DamlStateKey stateKey = DamlStateKey.newBuilder().set


### PR DESCRIPTION
This pull improves TP and RPC performance, but adding a degree of parallelism to the processing.  This increases the maxOccuppancy of the TP, by switching to a multi-threaded implementation of the base java transaction processor.  In addition some work has been done to reduce any potential contention between read and write addresses as well as eliminate the need for the log entry index. 