### PR TITLE
add intellij related extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@
 
 # exclude node modules
 **/node_modules/
+
+# exclude intellij items
+*.iml
+**/.idea


### PR DESCRIPTION
Add extensions for intellij project files to gitignore list so they do not inadvertently get added to source control if you are using intellij as your IDE for this project