### PR TITLE
Improve the daml-rpc and daml-tp parallel behavior

### DIFF
--- a/docker/daml-test.yaml
+++ b/docker/daml-test.yaml
@@ -43,7 +43,7 @@ services:
           -o config-genesis.batch && \
         sawset proposal create -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.min_wait_time=0 \
-          sawtooth.consensus.max_wait_time=2 \
+          sawtooth.consensus.max_wait_time=0 \
           -o consensus-settings.batch && \
         sawadm genesis config-genesis.batch consensus-settings.batch && \
         sawtooth-validator -v \
@@ -135,33 +135,33 @@ services:
     # TransactionServiceIT - not clear why this fails, certain tests report "RESOURCE_EXHAUSTED" and thats all we get so
     #                        far
     entrypoint: "bash -xc \"\
-      sleep 120 && \
+      sleep 60 && \
       java -jar ledger-api-test-tool.jar \
-        --timeout-scale-factor 6 \
+        --timeout-scale-factor 4 \
         --all-tests \
-        --exclude LotsOfPartiesIT,PartyManagementServiceIT,PackageManagementServiceIT,TimeIT,TransactionServiceIT \
-        --concurrent-test-runs 2 \
+        --exclude TimeIT,TransactionServiceIT \
+        --concurrent-test-runs 1 \
         daml-rpc:9000 \
         || \
       java -jar ledger-api-test-tool.jar \
-        --timeout-scale-factor 6 \
+        --timeout-scale-factor 4 \
         --all-tests \
-        --exclude LotsOfPartiesIT,PartyManagementServiceIT,PackageManagementServiceIT,TimeIT,TransactionServiceIT \
-        --concurrent-test-runs 2 \
+        --exclude TimeIT,TransactionServiceIT \
+        --concurrent-test-runs 1 \
         daml-rpc:9000 \
         || \
       java -jar ledger-api-test-tool.jar \
-        --timeout-scale-factor 6 \
+        --timeout-scale-factor 4 \
         --all-tests \
-        --exclude LotsOfPartiesIT,PartyManagementServiceIT,PackageManagementServiceIT,TimeIT,TransactionServiceIT \
-        --concurrent-test-runs 2 \
+        --exclude TimeIT,TransactionServiceIT \
+        --concurrent-test-runs 1 \
         daml-rpc:9000 \
         || \
       java -jar ledger-api-test-tool.jar \
-        --timeout-scale-factor 6 \
+        --timeout-scale-factor 4 \
         --all-tests \
-        --exclude LotsOfPartiesIT,PartyManagementServiceIT,PackageManagementServiceIT,TimeIT,TransactionServiceIT \
-        --concurrent-test-runs 2 \
+        --exclude TimeIT,TransactionServiceIT \
+        --concurrent-test-runs 1 \
         daml-rpc:9000 \
         \""
     depends_on:

--- a/sawtooth-daml-common/src/main/java/com/blockchaintp/sawtooth/daml/messaging/ZmqStream.java
+++ b/sawtooth-daml-common/src/main/java/com/blockchaintp/sawtooth/daml/messaging/ZmqStream.java
@@ -148,6 +148,26 @@ public class ZmqStream implements Stream {
     return result.getMessage();
   }
 
+
+  /**
+   * Get a message that has been received. If the timeout is expired, return null.
+   * Also put the resolution of the timer down to millis.
+   * @param timeout time to wait for a message.
+   * @return result, a protobuf Message
+   */
+  public final Message receiveNoException(final long timeout) {
+    SendReceiveThread.MessageWrapper result = null;
+    try {
+      result = this.receiveQueue.poll(timeout, TimeUnit.MILLISECONDS);
+      if (result == null) {
+        return null;
+      }
+    } catch (InterruptedException ie) {
+      return null;
+    }
+    return result.getMessage();
+
+  }
   /**
    * generate a random String, to correlate sent messages. with futures
    * @return a random String

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/MTTransactionProcessor.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/MTTransactionProcessor.java
@@ -44,8 +44,6 @@ public class MTTransactionProcessor implements Runnable {
 
   private static final int LOG_METRICS_INTERVAL = 1000;
 
-  private static final int DEFAULT_MAX_THREADS = 10;
-
   private static final Logger LOGGER = Logger.getLogger(MTTransactionProcessor.class.getName());
 
   private TransactionHandler handler;


### PR DESCRIPTION
This puts a guard in place so that the daml-rpc doesn't
submit more transactions than it can reasonably expect
responses from.  This is determined dynamically based on
the number of cores/threads available.

This also improves the responsiveness of the ZmqStream
dramatically, which in turn improves performance
quite a bit.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>