### PR TITLE
Fix postgres auth

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+      #    - id: check-yaml
+    - id: check-added-large-files
+    - id: check-json
+    - id: check-merge-conflict
+    - id: detect-aws-credentials
+    - id: detect-private-key
+    - id: mixed-line-ending
+- repo: https://github.com/jumanjihouse/pre-commit-hooks
+  rev: 1.11.2
+  hooks:
+    - id: markdownlint
+    - id: shellcheck
+    - id: script-must-have-extension
+    - id: script-must-not-have-extension
+    - id: shfmt
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.1.7
+  hooks:
+    - id: forbid-tabs
+      #  - id: insert-license
+      #- repo: https://github.com/doublify/pre-commit-clang-format
+      #  rev: master
+      #  hooks:
+      #    - id: clang-format

--- a/docker/compose/daml-local.yaml
+++ b/docker/compose/daml-local.yaml
@@ -44,6 +44,8 @@ services:
   postgres:
     image: postgres
     container_name: postgres
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   settings-tp:
     image: hyperledger/sawtooth-settings-tp:1.1

--- a/docker/daml-test.yaml
+++ b/docker/daml-test.yaml
@@ -59,6 +59,8 @@ services:
 
   postgres:
     image: postgres
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   devmode-engine:
     image: hyperledger/sawtooth-devmode-engine-rust:1.1


### PR DESCRIPTION
Postgres 11 has recently switched to disable host auth method of trust by default.  This is previously what we have used in our compose files since it was the default, and since these compose files are not meant for any production use.

Also taking the opportunity to add the pre-commit-config file.