### PR TITLE
Delay rpc and test start up by 30s

### DIFF
--- a/docker/daml-test.yaml
+++ b/docker/daml-test.yaml
@@ -102,6 +102,7 @@ services:
       - "9000:9000"
       - "5051:5051"
     entrypoint: "bash -c \"\
+      sleep 30 && \
       /opt/sawtooth-daml-rpc/entrypoint.sh --port 9000 \
         --connect tcp://validator:4004 \
         --jdbc-url jdbc:postgresql://postgres/postgres?user=postgres \
@@ -131,7 +132,7 @@ services:
     #          support (setting time)
     # TransactionScaleIT - scaling test that currently times out at 30s interval, disabling for the interim
     entrypoint: "bash -xc \"\
-      sleep 60 && \
+      sleep 90 && \
       java -jar ledger-api-test-tool.jar \
         --timeout-scale-factor 4 \
         --all-tests \


### PR DESCRIPTION
Seems to be a bit of an issue with the RPC starting up
before the validator is ready on the big CI machines.
Just adding an arbitrary delay here should do it, and
is sufficient for CI purposes.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>