### PR TITLE
Change min ttl to 29s so it is compatible with min ttl for navigator

### DIFF
--- a/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
+++ b/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
@@ -53,7 +53,7 @@ public class SawtoothReadService implements ReadService {
 
   private static final int DEFAULT_MAX_TTL = 80; //4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; //1x the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 29; //1.5x - 1 
 
   private static final Timestamp BEGINNING_OF_EPOCH = new Timestamp(0);
 

--- a/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
+++ b/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
@@ -53,7 +53,7 @@ public class SawtoothReadService implements ReadService {
 
   private static final int DEFAULT_MAX_TTL = 80; //4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 29; //1.5x - 1 the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; //1x the TimeKeeper period
 
   private static final Timestamp BEGINNING_OF_EPOCH = new Timestamp(0);
 

--- a/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
+++ b/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
@@ -53,7 +53,7 @@ public class SawtoothReadService implements ReadService {
 
   private static final int DEFAULT_MAX_TTL = 80; //4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; //1x the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 29; //1.5x - 1 the TimeKeeper period
 
   private static final Timestamp BEGINNING_OF_EPOCH = new Timestamp(0);
 

--- a/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
+++ b/sawtooth-daml-rpc/src/main/java/com/blockchaintp/sawtooth/daml/rpc/SawtoothReadService.java
@@ -53,7 +53,7 @@ public class SawtoothReadService implements ReadService {
 
   private static final int DEFAULT_MAX_TTL = 80; //4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 40; //2x the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; //1x the TimeKeeper period
 
   private static final Timestamp BEGINNING_OF_EPOCH = new Timestamp(0);
 

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
@@ -58,7 +58,7 @@ public final class DamlTransactionHandler implements TransactionHandler {
 
   private static final int DEFAULT_MAX_TTL = 80; // 4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 40; // 2x the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; // 1x the TimeKeeper period
 
   private static final Logger LOGGER = Logger.getLogger(DamlTransactionHandler.class.getName());
 

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
@@ -58,7 +58,7 @@ public final class DamlTransactionHandler implements TransactionHandler {
 
   private static final int DEFAULT_MAX_TTL = 80; // 4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; // 1x the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 29; //1.5x - 1
 
   private static final Logger LOGGER = Logger.getLogger(DamlTransactionHandler.class.getName());
 

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
@@ -58,7 +58,7 @@ public final class DamlTransactionHandler implements TransactionHandler {
 
   private static final int DEFAULT_MAX_TTL = 80; // 4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; // 1x the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 29; // 1.5x - 1 the TimeKeeper period
 
   private static final Logger LOGGER = Logger.getLogger(DamlTransactionHandler.class.getName());
 

--- a/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
+++ b/sawtooth-daml-tp/src/main/java/com/blockchaintp/sawtooth/daml/processor/impl/DamlTransactionHandler.java
@@ -58,7 +58,7 @@ public final class DamlTransactionHandler implements TransactionHandler {
 
   private static final int DEFAULT_MAX_TTL = 80; // 4x the TimeKeeper period
 
-  private static final int DEFAULT_MAX_CLOCK_SKEW = 29; // 1.5x - 1 the TimeKeeper period
+  private static final int DEFAULT_MAX_CLOCK_SKEW = 20; // 1x the TimeKeeper period
 
   private static final Logger LOGGER = Logger.getLogger(DamlTransactionHandler.class.getName());
 


### PR DESCRIPTION
Default usage of daml navigator at same 0.13.41 SDK version as sawtooth fails since navigator sends commands with a 30s ttl and the default range for daml-on-sawtooth is 40s-80s

This PR changes the default range to 30s-80s so that the navigator default is within range