### PR TITLE
Correct build.sh and docker/run.sh to deal with paths with empty spaces

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -16,16 +16,16 @@
 
 docker-compose -f docker/docker-compose-build.yaml build
 
-docker run -it --rm -v $HOME/.m2:/root/.m2 -v `pwd`:/project/daml-on-sawtooth \
+docker run -it --rm -v $HOME/.m2:/root/.m2 -v "$(pwd):/project/daml-on-sawtooth" \
     daml-on-sawtooth-build-local:${ISOLATION_ID} mvn -B clean
 
-docker run -it --rm -v $HOME/.m2:/root/.m2 -v `pwd`:/project/daml-on-sawtooth \
+docker run -it --rm -v $HOME/.m2:/root/.m2 -v "$(pwd):/project/daml-on-sawtooth" \
     daml-on-sawtooth-build-local:${ISOLATION_ID} mvn -B package
 
-docker run -it --rm -v $HOME/.m2:/root/.m2 -v `pwd`:/project/daml-on-sawtooth \
+docker run -it --rm -v $HOME/.m2:/root/.m2 -v "$(pwd):/project/daml-on-sawtooth" \
     daml-on-sawtooth-build-local:${ISOLATION_ID} chown -R $UID:$GROUPS /root/.m2/repository
 
-docker run -it --rm -v $HOME/.m2:/root/.m2 -v `pwd`:/project/daml-on-sawtooth \
+docker run -it --rm -v $HOME/.m2:/root/.m2 -v "$(pwd):/project/daml-on-sawtooth" \
     daml-on-sawtooth-build-local:${ISOLATION_ID} find /project -type d -name target \
     -exec chown -R $UID:$GROUPS {} \;
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,17 +3,17 @@
 COMMAND=$1
 
 function start(){
-    if [ -d ${PWD}/docker/keys ]; then
-        rm -rf ${PWD}/docker/keys
+    if [ -d "${PWD}/docker/keys" ]; then
+        rm -rf "${PWD}/docker/keys"
     fi
-    docker-compose -f ${PWD}/docker/compose/daml-local.yaml up
+    docker-compose -f "${PWD}/docker/compose/daml-local.yaml" up
 }
 
 function stop(){
-    if [ -d ${PWD}/docker/keys ]; then
-        rm -rf ${PWD}/docker/keys
+    if [ -d "${PWD}/docker/keys" ]; then
+        rm -rf "${PWD}/docker/keys"
     fi
-    docker-compose -f ${PWD}/docker/compose/daml-local.yaml down
+    docker-compose -f "${PWD}/docker/compose/daml-local.yaml" down
 }
 
 case "$COMMAND" in


### PR DESCRIPTION
This PR has two corrections related with Docker being unable to understand paths containing empty spaces.

When building the project at a path with empty spaces,
Docker was not able to correctly understand the path and
the build would fail.

```console
++ pwd
+ docker run -it --rm -v /Users/myuser/.m2:/root/.m2 -v /Users/myuser/Path with/Empty spaces/daml-on-sawtooth:/project/daml-on-sawtooth daml-on-sawtooth-build-local:my-local-build-202103181546 mvn -B clean
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
```

It would lead to an error when trying to build sawtooth-daml-tp:

```
 => ERROR [2/6] COPY ./sawtooth-daml-tp/target/sawtooth-daml-tp-*-bin.zip /opt
```

The other case is when launching the containers with `docker/run.sh`. It uses a path obtained with `pwd` and, when the path contains empty spaces, Docker is unable to understand it and the containers won't start.

Corrected the way the path is returned, so Docker can correctly
understand it. The full path is now between `""`.